### PR TITLE
Fix "Module parse failed" errors on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ async function gltfLoader(content) {
   // Emit the file:
   this.emitFile(interpolatedPath, updatedContent, null);
   // Join all paths together:
-  const fullPath = path.join(publicPath, interpolatedPath);
+  const fullPath = path.join(publicPath, interpolatedPath).replace(/\\/g, '/');
   // Lastly, resolve with either the JSON data or the full output path:
   return `export default ${inline ? updatedContent : `"${fullPath}"`}`;
 }


### PR DESCRIPTION
I encountered these errors when building on Windows:
 - Module parse failed: Invalid escape sequence
 - Module parse failed: Octal literal in strict mode

It seems to be caused by the backslash characters of Windows paths. Those are treated as either an escape sequence (e.g. `\n`) or an octal literal (e.g. `\345`) by JS.

Replacing backslash characters with forward slash characters in the exported file path fixed the issue.